### PR TITLE
Update spacing for extended summaries

### DIFF
--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -90,7 +90,9 @@ export default function Card({ tx, index }: { tx: TxRecord, index: number }) {
       return summary
     }
     console.log("story", parsedSummaries)
-    const story = parsedSummaries.map((item: ParsedLog, i: number) => <div key={i}>{item?.summary}</div>)
+    const story = parsedSummaries.map((item: ParsedLog, i: number) => (
+      <div key={i} style={{ marginBottom: '0.25rem' }}>{item?.summary}</div>
+    ))
     
     return <div className="summary">{summary} <br /> {story}</div>
   }


### PR DESCRIPTION
## Summary
- add margin-bottom to each extended summary item

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852533e1a08832d8a0b26e8fc402ba3